### PR TITLE
회원 관리 API 요청 매핑 추가

### DIFF
--- a/springmvc/src/main/java/hello/springmvc/basic/requestmapping/MappingClassController.java
+++ b/springmvc/src/main/java/hello/springmvc/basic/requestmapping/MappingClassController.java
@@ -1,0 +1,33 @@
+package hello.springmvc.basic.requestmapping;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/mapping/users")
+public class MappingClassController {
+
+    @GetMapping
+    public String user() {
+        return "get users";
+    }
+
+    @PostMapping
+    public String addUser() {
+        return "post user";
+    }
+
+    @GetMapping("/{userId}")
+    public String findUser(@PathVariable String userId) {
+        return "get userId=" + userId;
+    }
+
+    @PatchMapping("/{userId}")
+    public String updateUser(@PathVariable String userId) {
+        return "patch userId=" + userId;
+    }
+
+    @DeleteMapping("/{userId}")
+    public String deleteUser(@PathVariable String userId) {
+        return "delete userId=" + userId;
+    }
+}


### PR DESCRIPTION
#### 변경 사항
- 회원 목록 조회 API: `GET /users`
- 회원 등록 API: `POST /users`
- 회원 조회 API: `GET /users/{userId}`
- 회원 수정 API: `PATCH /users/{userId}`
- 회원 삭제 API: `DELETE /users/{userId}`
- `@RequestMapping("/mapping/users")`을 활용하여 클래스 레벨에서 공통 경로 적용

#### 테스트 방법
1. Postman 또는 cURL을 사용하여 API 요청을 실행
2. 예상 응답 확인:
   - `GET /mapping/users` → "get users"
   - `POST /mapping/users` → "post user"
   - `GET /mapping/users/id1` → "get userId=id1"
   - `PATCH /mapping/users/id1` → "update userId=id1"
   - `DELETE /mapping/users/id1` → "delete userId=id1"