### PR TITLE
HTTP 요청 헤더 조회 기능 추가

### DIFF
--- a/springmvc/src/main/java/hello/springmvc/basic/request/RequestHeaderController.java
+++ b/springmvc/src/main/java/hello/springmvc/basic/request/RequestHeaderController.java
@@ -1,0 +1,37 @@
+package hello.springmvc.basic.request;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Locale;
+
+@Slf4j
+@RestController
+public class RequestHeaderController {
+    @RequestMapping("/headers")
+    public String headers(HttpServletRequest request,
+                          HttpServletResponse response,
+                          HttpMethod httpMethod,
+                          Locale locale,
+                          @RequestHeader MultiValueMap<String, String> headerMap,
+                          @RequestHeader("host") String host,
+                          @CookieValue(value = "myCookie", required = false) String cookie
+                          ) {
+        log.info("request={}", request);
+        log.info("response={}", response);
+        log.info("httpMethod={}", httpMethod);
+        log.info("locale={}", locale);
+        log.info("headerMap={}", headerMap);
+        log.info("header host={}", host);
+        log.info("myCookie={}", cookie);
+
+        return "ok";
+    }
+}


### PR DESCRIPTION
#### 변경 사항
- `HttpServletRequest`, `HttpServletResponse`를 활용한 HTTP 요청 및 응답 처리
- `HttpMethod`를 사용하여 요청의 HTTP 메서드 확인 기능 추가
- `Locale`을 활용하여 클라이언트의 지역 정보를 조회하는 기능 추가
- `@RequestHeader MultiValueMap<String, String>`을 이용한 모든 HTTP 헤더 조회 기능 추가
- `@RequestHeader("host")`를 활용하여 특정 헤더 값(host) 조회 기능 추가
- `@CookieValue(value = "myCookie", required = false)`를 사용하여 특정 쿠키 값 조회 기능 추가

#### 테스트 방법
1. Postman 또는 URL을 이용하여 `/headers` 엔드포인트로 요청 전송
2. 응답 로그에서 요청 헤더 정보가 정상적으로 출력되는지 확인
3. 특정 쿠키가 없을 때도 정상적으로 동작하는지 검증